### PR TITLE
Support for no bin links flag in npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ function mochaPhantomJS(options) {
 
 function spawnPhantomJS(args, cb) {
   var phantomjsPath = lookup('.bin/phantomjs', true);
+  // case where npm is started with --no-bin-links
+  if (!phantomjsPath) {
+    phantomjsPath = lookup('phantomjs/bin/phantomjs', true);
+  }
   if (!phantomjsPath) {
     cb(new gutil.PluginError(pluginName, 'PhantomJS not found'));
   } else {


### PR DESCRIPTION
When npm has the no bin links flag, phantomjs won't be located in the .bin folder as npm won't symlink it. These lines search for phantomjs in the standard node_modules folder to fix this case.
