### PR TITLE
fix: emit end after the 'after_flush'

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function mochaPhantomJS(options) {
       // for testing purpose
       // be able to add a callback after _flush
       this.emit('after_flush');
+      this.emit('end');
     }.bind(this));
   });
 }


### PR DESCRIPTION
Emit end event after the after_flush event so that downstream pipes
can wait for tests to complete and not be hung doing so.
