### PR TITLE
Update phantomjs version to match mocha-phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^2.2.14",
     "mocha-phantomjs": "^3.3.2",
-    "phantomjs": "^1.9.0",
+    "phantomjs": "1.9.1 - 1.9.7-15",
     "through2": "^0.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

We recently hit a problem where gulp-mocha-phantomjs tries to install the latest version of phantomjs which is now 1.9.17.
The problem is that the current version of mocha-phantomjs has a peer dependency on phantomjs 1.9.1 - 1.9.7-15

One way to fix the problem is to update the phantomjs dependency to exactly match the one declared in mocha-phantomjs 3.3.2.

Another way to fix the problem could be updating to a newer version of mocha-phantomjs.

Could you please have a look at that one really quickly? it is a blocker for us at work.

Many thanks.