### PR TITLE
mocha-phantomjs-core no longer uses mochaPhantomJS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,7 @@ $ npm install gulp-mocha-phantomjs --save-dev
             });
         </script>
         <script>
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                mocha.run();
-            }
+            mocha.run();
         </script>
     </body>
 </html>

--- a/test/fixture-fail.html
+++ b/test/fixture-fail.html
@@ -18,11 +18,7 @@
             });
         </script>
         <script>
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                mocha.run();
-            }
+            mocha.run();
         </script>
     </body>
 </html>

--- a/test/fixture-pass.html
+++ b/test/fixture-pass.html
@@ -36,11 +36,7 @@
             });
         </script>
         <script>
-            if (window.mochaPhantomJS) {
-                mochaPhantomJS.run();
-            } else {
-                mocha.run();
-            }
+            mocha.run();
         </script>
     </body>
 </html>


### PR DESCRIPTION
Fixes #37. It’s now simply `mocha.run()`.

You can still detect if PhantomJS is running your tests with `window._phantom` or `window.callPhantom`.