### PR TITLE
Enforce the file:// protocol for correct url on windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var pluginName = require('./package.json').name;
 var extend = require('./extend');
+var fileUrl = require('file-url');
 
 function mochaPhantomJS(options) {
     options = options || {};
@@ -38,7 +39,7 @@ function mochaPhantomJS(options) {
 }
 
 function toURI(path, query) {
-    var parsed = url.parse(path, true);
+    var parsed = url.parse(fileUrl(path), true);
 
     parsed.query = extend(parsed.query, query);
     parsed.search = null;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "gulp test"
   },
   "dependencies": {
+    "file-url": "^1.0.1",
     "gulp-util": "^2.2.14",
     "mocha-phantomjs-core": "^1.0.0",
     "phantomjs": "1.9.1 - 1.9.7-15",


### PR DESCRIPTION
On windows, I was getting the error 'mocha was not found in the page within 10000ms of the page loading.'  

This was caused by the `toUri()` function not returning a correct file:// URI for a windows path like "D:\path\to\runner.html" because `url.parse()` considered the drive letter as a protocol.

To fix this I have converted the path to a file:// URI before passing it into the `url.parse()` function.