### PR TITLE
mocha and should are runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   },
   "dependencies": {
     "gulp-util": "^3.0.7",
+    "mocha": "^2.4.5",
     "mocha-phantomjs-core": "^2.0.0",
     "phantomjs-prebuilt": "^2.1.4",
+    "should": "^8.3.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.0",
     "gulp-mocha": "^2.2.0",
-    "jshint": "^2.9.1",
-    "mocha": "^2.4.5",
-    "should": "^8.2.1"
+    "jshint": "^2.9.1"
   },
   "homepage": "https://github.com/mrhooray/gulp-mocha-phantomjs",
   "repository": {


### PR DESCRIPTION
Running node example provided in README.md yields two errors.
Namely missing dependencies on `mocha` and `should`.