### PR TITLE
Added space escapes to URLs in phantom spawn args

### DIFF
--- a/extend.js
+++ b/extend.js
@@ -7,7 +7,7 @@ function extend() {
         var source = arguments[i];
 
         for (var key in source) {
-            if (source.hasOwnProperty(key)) {
+            if (source[key] !== undefined) {
                 target[key] = source[key];
             }
         }

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function spawnPhantomJS(args, options, stream, cb) {
         return cb(new gutil.PluginError(pluginName, 'PhantomJS not found'));
     }
 
-    if (phantomjsPath.indexOf(' ') !== -1) {
+    if (phantomjsPath.indexOf(' ') !== -1 || args[0].indexOf(' ') !== -1 || args[1].indexOf(' ') !== -1) {
         spawnOptions.shell = true;
     }
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function mochaPhantomJS(options) {
     return through.obj(function (file, enc, cb) {
         var args = [
             scriptPath,
-            toURL(file.path, options.mocha),
+            escapeSpaces(toURL(file.path, options.mocha)),
             options.reporter || 'spec',
             JSON.stringify(options.phantomjs || {})
         ];
@@ -71,6 +71,8 @@ function spawnPhantomJS(args, options, stream, cb) {
         return cb(new gutil.PluginError(pluginName, 'PhantomJS not found'));
     }
 
+    phantomjsPath = escapeSpaces(phantomjsPath);
+
     var phantomjs = spawn(phantomjsPath, args);
 
     if (options.dump) {
@@ -117,6 +119,10 @@ function lookup(path, isExecutable) {
             return absPath;
         }
     }
+}
+
+function escapeSpaces(str) {
+    return str.replace(/ /g, "\\ ");
 }
 
 module.exports = mochaPhantomJS;

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function lookup(path, isExecutable) {
 }
 
 function escapeSpaces(str) {
-    return str.replace(/ /g, "\\ ");
+    return str.replace(/ /g, '\\ ');
 }
 
 module.exports = mochaPhantomJS;

--- a/test/spaces pass.html
+++ b/test/spaces pass.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Mocha</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+    </head>
+    <body>
+        <script src="../node_modules/should/should.js"></script>
+        <script src="../node_modules/mocha/mocha.js"></script>
+        <script>mocha.setup('bdd')</script>
+        <script>
+            describe('true', function () {
+                it('should be true', function () {
+                    true.should.equal(true);
+                });
+            });
+        </script>
+        <script>
+            mocha.run();
+        </script>
+    </body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -133,7 +133,6 @@ describe('gulp-mocha-phantomjs', function () {
             }
         });
         var passed = false;
-        var oldWrite = process.stdout.write;
 
         stream.on('error', function () {
             assert.fail(undefined, undefined, 'should not emit error');
@@ -149,8 +148,6 @@ describe('gulp-mocha-phantomjs', function () {
             if (/3 passing/.test(str)) {
                 passed = true;
             }
-
-            oldWrite.apply(process.stdout, arguments);
         };
 
         stream.write(file);

--- a/test/test.js
+++ b/test/test.js
@@ -133,6 +133,7 @@ describe('gulp-mocha-phantomjs', function () {
             }
         });
         var passed = false;
+        var oldWrite = process.stdout.write;
 
         stream.on('error', function () {
             assert.fail(undefined, undefined, 'should not emit error');
@@ -148,6 +149,8 @@ describe('gulp-mocha-phantomjs', function () {
             if (/3 passing/.test(str)) {
                 passed = true;
             }
+
+            oldWrite.apply(process.stdout, arguments);
         };
 
         stream.write(file);
@@ -176,6 +179,31 @@ describe('gulp-mocha-phantomjs', function () {
             }
             if (/should be false/.test(str) || /should be true/.test(str)) {
                 assert.fail();
+            }
+        };
+
+        stream.write(file);
+        stream.end();
+    });
+
+    it('should handle uri with space propertly', function (cb) {
+        var file = new gutil.File({path: path.join(__dirname, 'spaces pass.html')});
+        var stream = mochaPhantomJS();
+        var passed = false;
+
+        stream.on('error', function () {
+            assert.fail(undefined, undefined, 'should not emit error');
+        });
+
+        stream.on('finish', function () {
+            assert.equal(passed, true);
+            process.stdout.write = out;
+            cb();
+        });
+
+        process.stdout.write = function (str) {
+            if (/1 passing/.test(str)) {
+                passed = true;
             }
         };
 


### PR DESCRIPTION
Fixes https://github.com/mrhooray/gulp-mocha-phantomjs/issues/69.

What's being passed to Node's `spawn` might have spaces in it. 

The following command...

```
path/with spaces/phantomjs url.html
         ^
```

...gets interpreted as:
- Command: `path/with`
- Args:
  - `spaces/phantomjs`
  - `url.html`

What we actually want is:

```
path/with\ spaces/phantomjs url.html
```
